### PR TITLE
Proposal: Remove note title from single page gates

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -11,7 +11,7 @@ export async function getStaticProps(context) {
   const conceptPrefix = getStringNoLocale(config, UG.conceptPrefix)
   const conceptUrl = getUrl(config, UG.usesConcept)
   const conceptIndexUrl = getUrl(config, UG.usesConceptIndex)
-  const { name, body } = await loadConcept(conceptIndexUrl, conceptUrl)
+  const { body } = await loadConcept(conceptIndexUrl, conceptUrl)
   const customCSS = getStringNoLocale(config, UG.usesCSS)
   const webId = getUrl(config, UG.monetizedFor)
   const paymentPointer = webId && await getPaymentPointer(webId)
@@ -35,9 +35,6 @@ export default function Home({ conceptPrefix, name, body, customCSS, paymentPoin
       </Head>
       <main className="min-h-screen">
         <section class="content">
-          <h1 className="title">
-            {name}
-          </h1>
           <div className="note-body">
             <NoteBody json={body} conceptPrefix={conceptPrefix} />
           </div>


### PR DESCRIPTION
Playing around with these a bit, I think they shouldn't include the note name, especially since we lowercase the note titles. I like how the link-in-bio gate work more (where it just uses the content), and I think it's a good pattern to get into. If you want a header you need to make that a head in the document.

Not confident about this change, but it wasn't super hard so figured I would make it and then we can discuss in the PR.